### PR TITLE
eugene/allow passing as is on cast fail

### DIFF
--- a/tool_use_package/tests/test_tool_user.py
+++ b/tool_use_package/tests/test_tool_user.py
@@ -12,6 +12,7 @@ class TestToolUser(unittest.TestCase):
         self.assertEqual(self.tool_user._convert_value("['a', 'c', 'e']", "list"), ["a", "c", "e"])
         self.assertEqual(self.tool_user._convert_value("The big orange cat ran.", "str"), "The big orange cat ran.")
         self.assertEqual(self.tool_user._convert_value("3", "int"), 3)
+        self.assertEqual(self.tool_user._convert_value("${get_current_user_id()}", "int"), "${get_current_user_id()}")
         with self.assertRaises(AttributeError):
             self.tool_user._convert_value("8", "canteloupe")
 

--- a/tool_use_package/tool_user.py
+++ b/tool_use_package/tool_user.py
@@ -274,14 +274,26 @@ class ToolUser:
     # TODO: This only handles the outer-most type. Nested types are an unimplemented issue at the moment.
     @staticmethod
     def _convert_value(value, type_str):
-        """Converts a string value into its appropriate Python data type based on the provided type string."""
+        """Convert a string value into its appropriate Python data type based on the provided type string.
+
+        Arg:
+            value: the value to convert
+            type_str: the type to convert the value to
+
+        Returns:
+            The value converted into the requested type or the original value
+            if the conversion failed.
+        """
 
         if type_str in ("list", "dict"):
             return ast.literal_eval(value)
         
         type_class = getattr(builtins, type_str)
-        return type_class(value)
-    
+        try:
+            return type_class(value)
+        except ValueError:
+            return value
+
     @staticmethod
     def _construct_prompt_from_messages(messages):
         return construct_prompt_from_messages(messages)


### PR DESCRIPTION
Fix for when cast fails.

This will keep the value as a string, and allow downstream code to create an error message to feed back into the llm, so the llm can correct its response.

```
ValueError("invalid literal for int() with base 10: '${get_current_user_id()}'")Traceback (most recent call last):


  File "/virtualenvs/langchain-benchmarks-mH3m7l2a-py3.11/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 1514, in invoke
    input = step.invoke(
            ^^^^^^^^^^^^


  File "/virtualenvs/langchain-benchmarks-mH3m7l2a-py3.11/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 2631, in invoke
    return self._call_with_config(
           ^^^^^^^^^^^^^^^^^^^^^^^


  File "/virtualenvs/langchain-benchmarks-mH3m7l2a-py3.11/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 886, in _call_with_config
    output = call_func_with_variable_args(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


  File "/virtualenvs/langchain-benchmarks-mH3m7l2a-py3.11/lib/python3.11/site-packages/langchain_core/runnables/config.py", line 308, in call_func_with_variable_args
    return func(input, **kwargs)  # type: ignore[call-arg]
           ^^^^^^^^^^^^^^^^^^^^^


  File "/virtualenvs/langchain-benchmarks-mH3m7l2a-py3.11/lib/python3.11/site-packages/langchain_core/runnables/base.py", line 2549, in _invoke
    output = call_func_with_variable_args(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


  File "/virtualenvs/langchain-benchmarks-mH3m7l2a-py3.11/lib/python3.11/site-packages/langchain_core/runnables/config.py", line 308, in call_func_with_variable_args
    return func(input, **kwargs)  # type: ignore[call-arg]
           ^^^^^^^^^^^^^^^^^^^^^


  File "/Users/wfh/code/lc/langchain-benchmarks/langchain_benchmarks/tool_usage/agents/anthropic_tool_user.py", line 206, in run_agent
    messages = run_anthropic_agent_simple(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^


  File "/Users/wfh/code/lc/langchain-benchmarks/langchain_benchmarks/tool_usage/agents/anthropic_tool_user.py", line 120, in run_anthropic_agent_simple
    last_message = tool_user.use_tools(
                   ^^^^^^^^^^^^^^^^^^^^


  File "/Users/wfh/code/lc/langchain-benchmarks/docs/source/notebooks/tool_usage/../../../../_anthropic_tools/anthropic-tools/tool_use_package/tool_user.py", line 110, in use_tools
    parsed_function_calls = self._parse_function_calls(
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^


  File "/Users/wfh/code/lc/langchain-benchmarks/docs/source/notebooks/tool_usage/../../../../_anthropic_tools/anthropic-tools/tool_use_package/tool_user.py", line 226, in _parse_function_calls
    converted_params[name] = ToolUser._convert_value(value, type_)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


  File "/Users/wfh/code/lc/langchain-benchmarks/docs/source/notebooks/tool_usage/../../../../_anthropic_tools/anthropic-tools/tool_use_package/tool_user.py", line 416, in _convert_value
    return type_class(value)
           ^^^^^^^^^^^^^^^^^


ValueError: invalid literal for int() with base 10: '${get_current_user_id()}'
```
